### PR TITLE
Use rb_check_frozen

### DIFF
--- a/ruby/ext/google/protobuf_c/map.c
+++ b/ruby/ext/google/protobuf_c/map.c
@@ -388,9 +388,7 @@ VALUE Map_index(VALUE _self, VALUE key) {
 VALUE Map_index_set(VALUE _self, VALUE key, VALUE value) {
   Map* self = ruby_to_Map(_self);
 
-  if (rb_obj_frozen_p(_self)) {
-    rb_raise(rb_eArgError, "object is frozen");
-  }
+  rb_check_frozen(_self);
 
   char keybuf[TABLE_KEY_BUF_LENGTH];
   const char* keyval = NULL;
@@ -444,9 +442,7 @@ VALUE Map_has_key(VALUE _self, VALUE key) {
 VALUE Map_delete(VALUE _self, VALUE key) {
   Map* self = ruby_to_Map(_self);
 
-  if (rb_obj_frozen_p(_self)) {
-    rb_raise(rb_eArgError, "object is frozen");
-  }
+  rb_check_frozen(_self);
 
   char keybuf[TABLE_KEY_BUF_LENGTH];
   const char* keyval = NULL;
@@ -471,9 +467,7 @@ VALUE Map_delete(VALUE _self, VALUE key) {
 VALUE Map_clear(VALUE _self) {
   Map* self = ruby_to_Map(_self);
 
-  if (rb_obj_frozen_p(_self)) {
-    rb_raise(rb_eArgError, "object is frozen");
-  }
+  rb_check_frozen(_self);
 
   // Uninit and reinit the table -- this is faster than iterating and doing a
   // delete-lookup on each key.

--- a/ruby/ext/google/protobuf_c/message.c
+++ b/ruby/ext/google/protobuf_c/message.c
@@ -216,9 +216,7 @@ VALUE Message_method_missing(int argc, VALUE* argv, VALUE _self) {
     if (argc != 2) {
       rb_raise(rb_eArgError, "Expected 2 arguments, received %d", argc);
     }
-    if (rb_obj_frozen_p(_self)) {
-      rb_raise(rb_eArgError, "object is frozen");
-    }
+    rb_check_frozen(_self);
   } else if (argc != 1) {
     rb_raise(rb_eArgError, "Expected 1 argument, received %d", argc);
   }

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -369,10 +369,10 @@ module BasicTest
       assert m.map_string_int32.frozen?
       assert m.map_string_msg.frozen?
 
-      assert_raise(ArgumentError) { m.map_string_int32['foo'] = 1 }
-      assert_raise(ArgumentError) { m.map_string_msg['bar'] = proto_module::TestMessage2.new }
-      assert_raise(ArgumentError) { m.map_string_int32.delete('a') }
-      assert_raise(ArgumentError) { m.map_string_int32.clear }
+      assert_raise(FrozenError) { m.map_string_int32['foo'] = 1 }
+      assert_raise(FrozenError) { m.map_string_msg['bar'] = proto_module::TestMessage2.new }
+      assert_raise(FrozenError) { m.map_string_int32.delete('a') }
+      assert_raise(FrozenError) { m.map_string_int32.clear }
     end
   end
 end

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1125,32 +1125,32 @@ module CommonTests
     m.optional_int32 = 10
     m.freeze
 
-    assert_raise(ArgumentError, 'object is frozen') do
+    assert_raise(FrozenError, 'can\'t modify frozen BasicTestProto2::TestMessage') do
       m.optional_int32 = 20
     end
     assert_equal 10, m.optional_int32
     assert_equal true, m.frozen?
 
-    assert_raise(ArgumentError) { m.optional_int64 = 2 }
-    assert_raise(ArgumentError) { m.optional_uint32 = 3 }
-    assert_raise(ArgumentError) { m.optional_uint64 = 4 }
-    assert_raise(ArgumentError) { m.optional_bool = true }
-    assert_raise(ArgumentError) { m.optional_float = 6.0 }
-    assert_raise(ArgumentError) { m.optional_double = 7.0 }
-    assert_raise(ArgumentError) { m.optional_string = '8' }
-    assert_raise(ArgumentError) { m.optional_bytes = nil }
-    assert_raise(ArgumentError) { m.optional_msg = proto_module::TestMessage2.new }
-    assert_raise(ArgumentError) { m.optional_enum = :A }
-    assert_raise(ArgumentError) { m.repeated_int32 = 1 }
-    assert_raise(ArgumentError) { m.repeated_int64 = 2 }
-    assert_raise(ArgumentError) { m.repeated_uint32 = 3 }
-    assert_raise(ArgumentError) { m.repeated_uint64 = 4 }
-    assert_raise(ArgumentError) { m.repeated_bool = true }
-    assert_raise(ArgumentError) { m.repeated_float = 6.0 }
-    assert_raise(ArgumentError) { m.repeated_double = 7.0 }
-    assert_raise(ArgumentError) { m.repeated_string = '8' }
-    assert_raise(ArgumentError) { m.repeated_bytes = nil }
-    assert_raise(ArgumentError) { m.repeated_msg = proto_module::TestMessage2.new }
-    assert_raise(ArgumentError) { m.repeated_enum = :A }
+    assert_raise(FrozenError) { m.optional_int64 = 2 }
+    assert_raise(FrozenError) { m.optional_uint32 = 3 }
+    assert_raise(FrozenError) { m.optional_uint64 = 4 }
+    assert_raise(FrozenError) { m.optional_bool = true }
+    assert_raise(FrozenError) { m.optional_float = 6.0 }
+    assert_raise(FrozenError) { m.optional_double = 7.0 }
+    assert_raise(FrozenError) { m.optional_string = '8' }
+    assert_raise(FrozenError) { m.optional_bytes = nil }
+    assert_raise(FrozenError) { m.optional_msg = proto_module::TestMessage2.new }
+    assert_raise(FrozenError) { m.optional_enum = :A }
+    assert_raise(FrozenError) { m.repeated_int32 = 1 }
+    assert_raise(FrozenError) { m.repeated_int64 = 2 }
+    assert_raise(FrozenError) { m.repeated_uint32 = 3 }
+    assert_raise(FrozenError) { m.repeated_uint64 = 4 }
+    assert_raise(FrozenError) { m.repeated_bool = true }
+    assert_raise(FrozenError) { m.repeated_float = 6.0 }
+    assert_raise(FrozenError) { m.repeated_double = 7.0 }
+    assert_raise(FrozenError) { m.repeated_string = '8' }
+    assert_raise(FrozenError) { m.repeated_bytes = nil }
+    assert_raise(FrozenError) { m.repeated_msg = proto_module::TestMessage2.new }
+    assert_raise(FrozenError) { m.repeated_enum = :A }
   end
 end

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1125,9 +1125,8 @@ module CommonTests
     m.optional_int32 = 10
     m.freeze
 
-    assert_raise(FrozenError, 'can\'t modify frozen BasicTestProto2::TestMessage') do
-      m.optional_int32 = 20
-    end
+    frozen_error = assert_raise(FrozenError) { m.optional_int32 = 20 }
+    assert_equal "can't modify frozen #{proto_module}::TestMessage", frozen_error.message
     assert_equal 10, m.optional_int32
     assert_equal true, m.frozen?
 


### PR DESCRIPTION
Instead of implementing the frozen object check ourselves, use Ruby's `rb_check_frozen` function. This change will raise `FrozenError` instead of `ArgumentError` when the objects are frozen.